### PR TITLE
Fixes & consistency improvements

### DIFF
--- a/docs/plugins/api/bdapi.md
+++ b/docs/plugins/api/bdapi.md
@@ -337,7 +337,7 @@ options.type|string|&#x2705;|"info" | "error" | "warning" | "success"|Type for t
 options.buttons|Array.&lt;{label: string, onClick: function()}&gt;|&#x2705;|*none*|Buttons that should be added next to the notice text.
 options.timeout|number|&#x2705;|10000|Timeout until the notice is closed. Won't fire if it's set to 0;
 
-**Returns:** `function` A function that closes the notice. Passing `true` as first parameters closes immediately without transitioning out.
+**Returns:** `function` A function that closes the notice. Passing `true` as first parameter closes immediately without transitioning out.
 ___
 
 ### showToast

--- a/docs/plugins/api/bdapi.md
+++ b/docs/plugins/api/bdapi.md
@@ -106,7 +106,7 @@ id|string|&#x274C;|*none*|Setting ID in the category
 ___
 
 ### enableSetting <span class="deprecated">Deprecated</span>
-Enable a BetterDiscord setting by ids.
+Enables a BetterDiscord setting by ids.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
@@ -118,37 +118,37 @@ id|string|&#x274C;|*none*|Setting ID in the category
 ___
 
 ### findAllModules <span class="deprecated">Deprecated</span>
-Finds multple webpack modules using a filter
+Finds multiple webpack modules using a filter.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
-filter|function|A filter given the exports, module, and moduleId. Returns true if the module matches.
+filter|function|A filter given the exports, module, and moduleId. Returns `true` if the module matches.
 
 **Returns:** `Array` - Either an array of matching modules or an empty array
 ___
 
 ### findModule <span class="deprecated">Deprecated</span>
-Finds a webpack module using a filter
+Finds a webpack module using a filter.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
-filter|function|A filter given the exports, module, and moduleId. Returns true if the module matches.
+filter|function|A filter given the exports, module, and moduleId. Returns `true` if the module matches.
 
 **Returns:** `any` - Either the matching module or `undefined`
 ___
 
 ### findModuleByDisplayName <span class="deprecated">Deprecated</span>
-Finds a webpack module by displayName property
+Finds a webpack module by its `displayName` property.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
-name|string|Desired displayName property
+name|string|Desired `displayName` property
 
 **Returns:** `any` - Either the matching module or `undefined`
 ___
 
 ### findModuleByProps <span class="deprecated">Deprecated</span>
-Finds a webpack module by own properties
+Finds a webpack module by its own properties.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
@@ -158,7 +158,7 @@ props|...string|Any desired properties
 ___
 
 ### findModuleByPrototypes <span class="deprecated">Deprecated</span>
-Finds a webpack module by own prototypes
+Finds a webpack module by its own prototypes.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
@@ -172,13 +172,13 @@ Gets some data in BetterDiscord's misc data.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
-key|string|Key of the data to load.
+key|string|Key of the data to load
 
 **Returns:** `any` - The stored data
 ___
 
 ### getInternalInstance
-Get the internal react data of a specified node
+Gets the internal react data of a specified node.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
@@ -199,7 +199,7 @@ css|string|CSS to apply to the document
 ___
 
 ### isSettingEnabled <span class="deprecated">Deprecated</span>
-Gets a specific setting's status from BD
+Gets a specific setting's status from BD.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
@@ -233,7 +233,7 @@ key|string|Which piece of data to load
 ___
 
 ### monkeyPatch <span class="deprecated">Deprecated</span>
-This function monkey-patches a method on an object. The patching callback may be run before, after or instead of target method.
+Monkey-patches a method on an object. The patching callback may be run before, after or instead of target method.
 
  - Be careful when monkey-patching. Think not only about original functionality of target method and your changes, but also about developers of other plugins, who may also patch this method before or after you. Try to change target method behaviour as little as possible, and avoid changing method signatures.
  - Display name of patched method is changed, so you can see if a function has been patched (and how many times) while debugging or in the stack trace. Also, patched methods have property `__monkeyPatched` set to `true`, in case you want to check something programmatically.
@@ -264,7 +264,7 @@ callback|function|Function to run when fired
 ___
 
 ### openDialog
-Gives access to the [Electron Dialog](https://www.electronjs.org/docs/latest/api/dialog/) api.
+Gives access to the [Electron Dialog](https://www.electronjs.org/docs/latest/api/dialog/) API.
 Returns a `Promise` that resolves to an `object` that has a `boolean` cancelled and a `filePath` string for saving and a `filePaths` string array for opening.
 
 | Parameter |  Type  | Optional | Default |       Description      |
@@ -327,7 +327,7 @@ options.onCancel|callable|&#x2705;|NOOP|callback to occur when clicking the canc
 ___
 
 ### showNotice
-Show a notice above discord's chat layer.
+Shows a notice above Discord's chat layer.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
@@ -341,7 +341,7 @@ options.timeout|number|&#x2705;|10000|Timeout until the notice is closed. Won't 
 ___
 
 ### showToast
-This shows a toast similar to android towards the bottom of the screen.
+Shows a toast similar to Android towards the bottom of the screen.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
@@ -377,7 +377,7 @@ data|object|Data to be tested
 ___
 
 ### toggleSetting <span class="deprecated">Deprecated</span>
-Toggle a BetterDiscord setting by ids.
+Toggles a BetterDiscord setting by ids.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|

--- a/docs/plugins/api/bdapi.md
+++ b/docs/plugins/api/bdapi.md
@@ -233,7 +233,10 @@ key|string|Which piece of data to load
 ___
 
 ### monkeyPatch <span class="deprecated">Deprecated</span>
-This function monkey-patches a method on an object. The patching callback may be run before, after or instead of target method. - Be careful when monkey-patching. Think not only about original functionality of target method and your changes, but also about developers of other plugins, who may also patch this method before or after you. Try to change target method behaviour as little as possible, and avoid changing method signatures. - Display name of patched method is changed, so you can see if a function has been patched (and how many times) while debugging or in the stack trace. Also, patched methods have property `__monkeyPatched` set to `true`, in case you want to check something programmatically.
+This function monkey-patches a method on an object. The patching callback may be run before, after or instead of target method.
+
+ - Be careful when monkey-patching. Think not only about original functionality of target method and your changes, but also about developers of other plugins, who may also patch this method before or after you. Try to change target method behaviour as little as possible, and avoid changing method signatures.
+ - Display name of patched method is changed, so you can see if a function has been patched (and how many times) while debugging or in the stack trace. Also, patched methods have property `__monkeyPatched` set to `true`, in case you want to check something programmatically.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
@@ -261,7 +264,8 @@ callback|function|Function to run when fired
 ___
 
 ### openDialog
-Gives access to the [Electron Dialog](https://www.electronjs.org/docs/latest/api/dialog/) api.Returns a `Promise` that resolves to an `object` that has a `boolean` cancelled and a `filePath` string for saving and a `filePaths` string array for opening.
+Gives access to the [Electron Dialog](https://www.electronjs.org/docs/latest/api/dialog/) api.
+Returns a `Promise` that resolves to an `object` that has a `boolean` cancelled and a `filePath` string for saving and a `filePaths` string array for opening.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
@@ -295,13 +299,14 @@ data|any|The data to be saved
 ___
 
 ### setBDData <span class="deprecated">Deprecated</span>
-Gets some data in BetterDiscord's misc data.
+Sets some data in BetterDiscord's misc data.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
-key|string|Key of the data to load.
+key|string|Key of the data to store
+data|any|The data to be saved
 
-**Returns:** `any` - The stored data
+**Returns:** `void`
 ___
 
 ### showConfirmationModal

--- a/docs/plugins/api/bdapi.md
+++ b/docs/plugins/api/bdapi.md
@@ -337,7 +337,7 @@ options.type|string|&#x2705;|"info" | "error" | "warning" | "success"|Type for t
 options.buttons|Array.&lt;{label: string, onClick: function()}&gt;|&#x2705;|*none*|Buttons that should be added next to the notice text.
 options.timeout|number|&#x2705;|10000|Timeout until the notice is closed. Won't fire if it's set to 0;
 
-**Returns:** `function`
+**Returns:** `function` A function that closes the notice. Passing `true` as first parameters closes immediately without transitioning out.
 ___
 
 ### showToast

--- a/docs/plugins/api/filters.md
+++ b/docs/plugins/api/filters.md
@@ -9,7 +9,7 @@ Series of [Filters](./filters) to be used for finding webpack modules.
 ## Methods
 
 ### byDisplayName
-Generates a function that filters by a set of properties.
+Generates a function that filters by the `displayName` property.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|

--- a/docs/plugins/api/patcher.md
+++ b/docs/plugins/api/patcher.md
@@ -10,8 +10,8 @@ This is extremely useful for modifying the internals of Discord by adjusting ret
 ## Methods
 
 ### after
-This method patches onto another function, allowing your code to run instead.
-Using this, you are also able to modify the return value, using the return of your code instead.
+This method patches onto another function, allowing your code to run afterwards.
+Using this, you are able to modify the return value after the original method is run.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|
@@ -49,7 +49,7 @@ ___
 
 ### instead
 This method patches onto another function, allowing your code to run instead.
-Using this, you are also able to modify the return value, using the return of your code instead.
+Using this, you are able to replace the original completely. You can still call the original manually if needed.
 
 | Parameter |  Type  |       Description      |
 |:----------|:------:|:----------------------:|

--- a/docs/plugins/api/webpack.md
+++ b/docs/plugins/api/webpack.md
@@ -1,6 +1,7 @@
 # Webpack
 
-`Webpack` is a utility class for getting internal webpack modules. Instance is accessible through the [BdApi](./bdapi).This is extremely useful for interacting with the internals of Discord.
+`Webpack` is a utility class for getting internal webpack modules. Instance is accessible through the [BdApi](./bdapi).
+This is extremely useful for interacting with the internals of Discord.
 
 ## Properties
 
@@ -31,7 +32,7 @@ Finds a module using a filter function.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
-filter|function|&#x274C;|*none*|A function to use to filter modules. It is given exports, module, and moduleID. Return true to signify match.
+filter|function|&#x274C;|*none*|A function to use to filter modules. It is given exports, module, and moduleID. Return `true` to signify match.
 options|object|&#x2705;|*none*|Whether to return only the first matching module
 options.first|Boolean|&#x2705;|true|Whether to return only the first matching module
 options.defaultExport|Boolean|&#x2705;|true|Whether to return default export when matching the default export
@@ -40,11 +41,11 @@ options.defaultExport|Boolean|&#x2705;|true|Whether to return default export whe
 ___
 
 ### waitForModule
-Finds a module that lazily loaded.
+Finds a module that is lazily loaded.
 
 | Parameter |  Type  | Optional | Default |       Description      |
 |:----------|:------:|:--------:|:-------:|:----------------------:|
-filter|function|&#x274C;|*none*|A function to use to filter modules. It is given exports. Return true to signify match.
+filter|function|&#x274C;|*none*|A function to use to filter modules. It is given exports. Return `true` to signify match.
 options|object|&#x2705;|*none*|Whether to return only the first matching module
 options.signal|AbortSignal|&#x2705;|*none*|AbortSignal of an AbortController to cancel the promise
 options.defaultExport|Boolean|&#x2705;|true|Whether to return default export when matching the default export

--- a/docs/plugins/introduction/structure.md
+++ b/docs/plugins/introduction/structure.md
@@ -136,7 +136,7 @@ These are functions that plugins _can_ make use of but are not required at all. 
 
 ##### getSettingsPanel
 
-This function allows your plugins to have a settings panel displayed through BetterDiscord. The expecting return type is either an `HTMLElement` or a `string` representing the HTML.
+This function allows your plugins to have a settings panel displayed through BetterDiscord. The expected return type is either an `HTMLElement` or a React element. Returning a `string` representing the HTML is deprecated.
 
 ##### observer
 

--- a/docs/themes/introduction/guidelines.md
+++ b/docs/themes/introduction/guidelines.md
@@ -36,4 +36,4 @@ These are guidelines that all themes are expected to abide by. Any themes that v
 
 ## Design
 1. Themes should not be a basic recolor or background change. Themes should significantly alter the look and feel of Discord.
-1. Themes should have full coverage of most common pages, popouts, modals and controls. Keep in mind that changing discord's variables does not provide full coverage of the app.
+1. Themes should have full coverage of most common pages, popouts, modals and controls. Keep in mind that changing Discord's variables does not provide full coverage of the app.


### PR DESCRIPTION
This PR:
- Fixes `BdApi.setBDData` having a copy `BdApi.getBDData`'s documentation
- Fixes the undocumented return type of `BdApi.showNotice`
- Fixes `Filters.byDisplayName` having a copy of `Filters.byProps`' documentation
- Fixes `Patcher.after` having a copy of `Patcher.instead`'s documentation
- Adjusts `Patcher.instead`'s a bit confusing 2nd sentence
- Fixes mentioned return types of `getSettingsPanel`: added React element, clarified HTML string is deprecated
- Fixes some typos, e.g. "multple" in `BdApi.findAllModules` or missing "is" in `Webpack.waitForModule`
- Changes some descriptions for consistency, e.g. to start with a verb (3rd person) and end with "."
- Adds inline codeblocks around mentions of `true` value & `displayName` property