### PR TITLE
Fix getSettingsPanel return

### DIFF
--- a/docs/plugins/introduction/structure.md
+++ b/docs/plugins/introduction/structure.md
@@ -136,7 +136,7 @@ These are functions that plugins _can_ make use of but are not required at all. 
 
 ##### getSettingsPanel
 
-This function allows your plugins to have a settings panel displayed through BetterDiscord. The expecting return type is either an `HTMLElement` or a `string` representing the HTML.
+This function allows your plugins to have a settings panel displayed through BetterDiscord. The expected return type is either an `HTMLElement` or a React element. Returning a `string` representing the HTML is deprecated.
 
 ##### observer
 

--- a/docs/themes/introduction/guidelines.md
+++ b/docs/themes/introduction/guidelines.md
@@ -36,4 +36,4 @@ These are guidelines that all themes are expected to abide by. Any themes that v
 
 ## Design
 1. Themes should not be a basic recolor or background change. Themes should significantly alter the look and feel of Discord.
-1. Themes should have full coverage of most common pages, popouts, modals and controls. Keep in mind that changing discord's variables does not provide full coverage of the app.
+1. Themes should have full coverage of most common pages, popouts, modals and controls. Keep in mind that changing Discord's variables does not provide full coverage of the app.


### PR DESCRIPTION
This fixes the mentioned possible return types of `getSettingsPanel`: added React element and clarified HTML string is deprecated.
Edit: Also fixes capitalization for a mention of Discord in theme guidelines.