### PR TITLE
Fix zsh:1: unmatched ' Error

### DIFF
--- a/docs/users/guides/vanilla.mdx
+++ b/docs/users/guides/vanilla.mdx
@@ -69,7 +69,7 @@ Creating a separate shortcut makes it easy to launch with either vanilla Discord
 1. Open Automator app (`⌘ Command`+`Spacebar`)
 1. Select `New Document` then `Application`
 1. From the menu on the left drag `Run Shell Script` to the right hand side.
-1. On the right, in the textbox that appears, paste in `open -a '/Applications/Discord.app; --args --vanilla`
+1. On the right, in the textbox that appears, paste in `open -a '/Applications/Discord.app' --args --vanilla`
 1. At the top, name your application something like `Discord Vanilla` and set `Where` to be the `Applications` folder
 1. Go to `File > Save` to finalize
 


### PR DESCRIPTION
Changed `;` to `'` since it was giving `zsh:1: unmatched '` error in Automator.