### PR TITLE
Update deprecated methods in plugin guide

### DIFF
--- a/docs/plugins/basics/addons.md
+++ b/docs/plugins/basics/addons.md
@@ -85,7 +85,7 @@ class MyPlugin {
                 myGreeting = zalgoPlugin.format(myGreeting);
             }
         }
-        BdApi.showToast(myGreeting);
+        BdApi.UI.showToast(myGreeting);
     }
 
     stop() {

--- a/docs/plugins/basics/dom.md
+++ b/docs/plugins/basics/dom.md
@@ -116,12 +116,12 @@ const serverList = document.querySelector(".tree-3agP2X > div > div[aria-label]"
 serverList.append(myButton);
 
 // This part re-adds it when removed
-BdApi.onRemoved(myButton, () => {
+BdApi.DOM.onRemoved(myButton, () => {
     serverList.append(myButton);
 });
 ```
 
-This is much cleaner and more descriptive of the action being taken. This is just one of the many helper functions that exist in `BdApi`. You'll learn more as you go through the docs. In fact, there are two more functions `injectCSS` and `clearCSS` that can be helpful for our button example.
+This is much cleaner and more descriptive of the action being taken. This is just one of the many helper functions that exist in `BdApi`. You'll learn more as you go through the docs. In fact, there are two more functions `addStyle` and `removeStyle` that can be helpful for our button example.
 
 These are pretty simple and straightforward. Say we added a class `my-button` to our button from before. We could then style it with css externally using this snippet:
 ```css
@@ -133,10 +133,10 @@ These are pretty simple and straightforward. Say we added a class `my-button` to
 }
 ```
 
-which is great and works, but we need to have it in our plugin. You can either create and add your own stylesheet to the document using the techniques at the beginning of this page, or you just use `BdApi.injectCSS`. Given an ID and your css, it'll take care of the rest.
+which is great and works, but we need to have it in our plugin. You can either create and add your own stylesheet to the document using the techniques at the beginning of this page, or you just use `BdApi.DOM.addStyle`. Given an ID and your css, it'll take care of the rest.
 
 ```js
-BdApi.injectCSS("myPluginName", `.my-button {
+BdApi.DOM.addStyle("myPluginName", `.my-button {
     padding: 4px;
     border-radius: 5px;
     background: black;
@@ -147,7 +147,7 @@ BdApi.injectCSS("myPluginName", `.my-button {
 which can later be removed using the same ID from before
 
 ```js
-BdApi.clearCSS("myPluginName");
+BdApi.DOM.removeStyle("myPluginName");
 ```
 
 Try playing around with this and all the techniques discussed above. When you feel comfortable, go ahead and move on to the next section.

--- a/docs/plugins/basics/settings.mdx
+++ b/docs/plugins/basics/settings.mdx
@@ -58,7 +58,7 @@ Where you store this object in your plugin is up to the individual developer. It
 
 ### Saving Settings
 
-BetterDiscord gives you an easy way to save your settings in a JSON file using `BdApi.saveData`. This function takes your plugin's name, the key you want to save and the corresponding data to save. This means you can save your entire settings object from above under a single key, or save each key invidually. See the examples below to help understand the difference.
+BetterDiscord gives you an easy way to save your settings in a JSON file using `BdApi.Data.save`. This function takes your plugin's name, the key you want to save and the corresponding data to save. This means you can save your entire settings object from above under a single key, or save each key invidually. See the examples below to help understand the difference.
 
 Saving the whole settings object under a single key:
 
@@ -77,7 +77,7 @@ const mySettings = {
     setting5: false
 };
 
-BdApi.saveData("myPlugin", "settings", mySettings);
+BdApi.Data.save("myPlugin", "settings", mySettings);
 ```
 
 </TabItem>
@@ -124,7 +124,7 @@ const mySettings = {
 const keys = Object.keys(mySettings);
 
 for (const key of keys) {
-    BdApi.saveData("myPlugin", key, mySettings[key]);
+    BdApi.Data.save("myPlugin", key, mySettings[key]);
 }
 ```
 
@@ -154,7 +154,7 @@ The first options--saving the entire object under a single key--may seem redunda
 
 ### Loading Settings
 
-Similar to above, BetterDiscord gives you an easy way to load your settings from a JSON file using `BdApi.loadData`. This function takes your plugin's name and the key you want to load. Just like before, you can have everything saved under one `settings` key, or saved individually in multiple keys. These are illustrated below.
+Similar to above, BetterDiscord gives you an easy way to load your settings from a JSON file using `BdApi.Data.load`. This function takes your plugin's name and the key you want to load. Just like before, you can have everything saved under one `settings` key, or saved individually in multiple keys. These are illustrated below.
 
 Loading the whole settings object from a single key:
 
@@ -162,7 +162,7 @@ Loading the whole settings object from a single key:
 <TabItem value="js" label="JS">
 
 ```js showLineNumbers
-const mySettings = BdApi.loadData("myPlugin", "settings");
+const mySettings = BdApi.Data.load("myPlugin", "settings");
 ```
 
 </TabItem>
@@ -199,7 +199,7 @@ const mySettings = {};
 const keys = ["setting1", "setting2", "setting3", "setting4", "setting5"];
 
 for (const key of keys) {
-    mySettings[key] = BdApi.loadData("myPlugin", key);
+    mySettings[key] = BdApi.Data.load("myPlugin", key);
 }
 ```
 
@@ -236,7 +236,7 @@ One common issue developers run into is default settings. Having defaults is ext
 <TabItem value="js" label="JS">
 
 ```js showLineNumbers
-const mySettings = BdApi.loadData("myPlugin", "settings");
+const mySettings = BdApi.Data.load("myPlugin", "settings");
 const myButton = document.getElementById("my-button");
 myButton.style.color = mySettings.accentColor; // undefined
 ```
@@ -266,7 +266,7 @@ const myDefaults = {
     accentColor: "blue"
 };
 
-const mySettings = Object.assign({}, myDefaults, BdApi.loadData("myPlugin", "settings"));
+const mySettings = Object.assign({}, myDefaults, BdApi.Data.load("myPlugin", "settings"));
 const myButton = document.getElementById("my-button");
 myButton.style.color = mySettings.accentColor; // "blue"
 ```
@@ -296,7 +296,7 @@ const myDefaults = {
 };
 
 const mySettings = {};
-const storedData = BdApi.loadData("myPlugin", "settings");
+const storedData = BdApi.Data.load("myPlugin", "settings");
 Object.assign(mySettings, myDefaults, storedData);
 ```
 
@@ -449,7 +449,7 @@ function buildSetting(text, key, type, value, callback = () => {}) {
     input.addEventListener("change", () => {
         const newValue = type == "checkbox" ? input.checked : input.value;
         mySettings[key] = newValue;
-        BdApi.saveData(meta.name, "settings", mySettings);
+        BdApi.Data.save(meta.name, "settings", mySettings);
         callback(newValue);
     });
     setting.append(label, input);
@@ -495,7 +495,7 @@ If we put all the pieces together and combine it with the button we made in the 
         input.addEventListener("change", () => {
             const newValue = type == "checkbox" ? input.checked : input.value;
             mySettings[key] = newValue;
-            BdApi.saveData(meta.name, "settings", mySettings);
+            BdApi.Data.save(meta.name, "settings", mySettings);
             callback(newValue);
         });
         setting.append(label, input);
@@ -525,7 +525,7 @@ If we put all the pieces together and combine it with the button we made in the 
 
   return {
     start: () => {
-        Object.assign(mySettings, BdApi.loadData(meta.name, "settings"));
+        Object.assign(mySettings, BdApi.Data.load(meta.name, "settings"));
         const serverList = document.querySelector("#app-mount");
         serverList.append(myButton);
         updateButtonText();

--- a/docs/plugins/basics/ui.mdx
+++ b/docs/plugins/basics/ui.mdx
@@ -73,7 +73,7 @@ There are some utility functions from `BdApi` that help you build and display ce
 
 ### alert
 
-The `BdApi.alert()` method allows you to create and display a simple yet extensible informational modal. Its signature is `alert(title, content)`.
+The `BdApi.UI.alert()` method allows you to create and display a simple yet extensible informational modal. Its signature is `alert(title, content)`.
 
 The most straightforward way to use it, is to just use strings.
 
@@ -81,7 +81,7 @@ The most straightforward way to use it, is to just use strings.
 <TabItem value="code">
 
 ```js
-BdApi.alert("Hello World", "This is just a basic informational modal!");
+BdApi.UI.alert("Hello World", "This is just a basic informational modal!");
 ```
 
 </TabItem>
@@ -99,7 +99,7 @@ You can also pass in a react element for `content` but <u>not for `title`</u>. H
 <TabItem value="code">
 
 ```jsx
-BdApi.alert("Hello World", <div>This is just a basic informational modal!</div>);
+BdApi.UI.alert("Hello World", <div>This is just a basic informational modal!</div>);
 ```
 
 </TabItem>
@@ -125,7 +125,7 @@ function MySearchInput(props) {
             />;
 }
 
-BdApi.alert(
+BdApi.UI.alert(
     "Input Test",
     <MySearchInput
         placeholder="Testing..."
@@ -160,7 +160,7 @@ Under the covers, `alert` makes use of `showConfirmationModal`. This one is an e
 <TabItem value="code">
 
 ```js
-BdApi.showConfirmationModal("Hello World", "This is just a basic confirmation modal!");
+BdApi.UI.showConfirmationModal("Hello World", "This is just a basic confirmation modal!");
 ```
 
 </TabItem>
@@ -186,7 +186,7 @@ function MySearchInput(props) {
             />;
 }
 
-BdApi.showConfirmationModal(
+BdApi.UI.showConfirmationModal(
     "Input Test",
     <MySearchInput
         placeholder="Find..."
@@ -222,7 +222,7 @@ Since toasts are meant to be simple and straightforward messages to the user, ma
 <TabItem value="code">
 
 ```js
-BdApi.showToast("This is just a basic toast!");
+BdApi.UI.showToast("This is just a basic toast!");
 ```
 
 </TabItem>
@@ -272,7 +272,7 @@ This function has the same signature as `showToast` with the except that `conten
 <TabItem value="code">
 
 ```js
-BdApi.showNotice("This is just a basic informational notice!");
+BdApi.UI.showNotice("This is just a basic informational notice!");
 ```
 
 </TabItem>
@@ -290,7 +290,7 @@ They can do more than just show information though, you can also add multiple bu
 <TabItem value="code">
 
 ```js
-BdApi.showNotice(
+BdApi.UI.showNotice(
     "This is just a basic informational notice!",
     {
         type: "error",


### PR DESCRIPTION
Changes deprecated methods to their newer counterparts in the basic plugin guide.

e.g.
`BdApi.showToast` -> `BdApi.UI.showToast`