### PR TITLE
Fix typos throughout User Guides and update some outdated information

### DIFF
--- a/docs/users/getting-started/configuration.md
+++ b/docs/users/getting-started/configuration.md
@@ -51,7 +51,7 @@ This option lets the CSS editor update as you type rather than waiting for you t
 
 ### Editor Location
 
-This option determines what editor should open when editing the custom CSS.
+This option determines which editor should open when editing custom CSS.
 
 
 ## Editor Preferences

--- a/docs/users/getting-started/configuration.md
+++ b/docs/users/getting-started/configuration.md
@@ -64,7 +64,7 @@ This option determines whether or not line numbers should be shown.
 
 ### Minimap
 
-This option determines if the minimap that represents the code on the right side should be hidden or shown.
+This option determines if the minimap that represents the code on the right-hand side should be hidden or shown.
 
 ### Reference Tooltips
 

--- a/docs/users/getting-started/configuration.md
+++ b/docs/users/getting-started/configuration.md
@@ -60,7 +60,7 @@ Settings that affect all editors used inside BetterDiscord.
 
 ### Line Numbers
 
-This option determines whether or not line numbers should be shown.
+This option simply determines whether or not line numbers should be shown.
 
 ### Minimap
 

--- a/docs/users/getting-started/configuration.md
+++ b/docs/users/getting-started/configuration.md
@@ -68,7 +68,7 @@ This option determines if the minimap that represents the code on the right-hand
 
 ### Reference Tooltips
 
-This option shows tooltips when hovering over parts of your code. For CSS this would be selector information. For JavaScript, this would be variable information.
+This option shows tooltips when hovering over parts of your code. For CSS, this would be selector information. For JavaScript, this would be variable information.
 
 ### Quick Suggestions
 

--- a/docs/users/getting-started/configuration.md
+++ b/docs/users/getting-started/configuration.md
@@ -11,17 +11,9 @@ BetterDiscord has a number of settings and options for you to adjust your experi
 
 These are settings that control whole modules of BetterDiscord.
 
-### Emote System
-
-This option allows you to toggle the Twitch emote system on or off. If you don't use it, it's good to leave this off as it saves your computer some RAM and CPU power.
-
-### Public Servers
-
-This option shows or hides the Public Servers button. If you don't use it, feel free to turn it off.
-
 ### Voice Disconnect
 
-This option causes you to disconnect from a voice call when you close Discord. By default Discord will try to auto-reconnect you which can be annoying to some.
+This option causes you to disconnect from a voice call when you close Discord. By default, Discord will try to auto-reconnect you which can be annoying to some.
 
 ### Show Toasts
 
@@ -51,12 +43,15 @@ This option determines what should happen when you click the edit button on an a
 
 ### Custom CSS
 
-This option allows you to completely disable the custom css system. If you don't use it, turning this off saves you a bit of RAM and CPU power.
+This option allows you to completely disable the custom CSS system. If you don't use it, turning this off saves you a bit of RAM and CPU power.
 
 ### Live Update
 
-This options lets the css editor update as you type rather than waiting for you to click the button.
+This option lets the CSS editor update as you type rather than waiting for you to click the button.
 
+### Editor Location
+
+This option determines what editor should open when editing the custom CSS.
 
 
 ## Editor Preferences
@@ -65,15 +60,15 @@ Settings that affect all editors used inside BetterDiscord.
 
 ### Line Numbers
 
-This option simply determines whether or not line numbers should be shown.
+This option determines whether or not line numbers should be shown.
 
 ### Minimap
 
-This option determines if the minimap that represents the code on the right had side should be hidden or shown.
+This option determines if the minimap that represents the code on the right side should be hidden or shown.
 
 ### Reference Tooltips
 
-This option shows tooltips when hovering over parts of your code. For CSS this would be selector information. For JavaScript this would be variable information.
+This option shows tooltips when hovering over parts of your code. For CSS this would be selector information. For JavaScript, this would be variable information.
 
 ### Quick Suggestions
 
@@ -95,11 +90,11 @@ Settings related to the main window of Discord.
 
 ### Enable Transparency
 
-This option enables Electron's transparency mode. By itself this option doesn't do much, but if you have a theme that changes the opacity of the root element, you can actually see through the Discord client to your desktop. On Windows, having this enabled breaks aero snapping and other common window features. This is a limitation of Electron itself and not something BetterDiscord can fix.
+This option enables Electron's transparency mode. By itself, this option doesn't do much, but if you have a theme that changes the opacity of the root element, you can actually see through the Discord client to your desktop. On Windows, having this enabled breaks aero snapping and other common window features. This is a limitation of Electron itself and not something BetterDiscord can fix.
 
 ### Remove Minimum Size
 
-This option gets rid of Discord's forced minimum window size. For many users this limit is too large to be able to customize their viewscreen.
+This option gets rid of Discord's forced minimum window size. For many users, this limit is too large to be able to customize their viewscreen.
 
 
 
@@ -113,7 +108,7 @@ This option causes BetterDiscord to output everything from the chromium console 
 
 ### DevTools
 
-This option allows you to open the chromium devtools with the usually `ctrl`+`shift`+`i` combination. If you're not a developer, best to leave this off.
+This option allows you to open the chromium devtools with the usual `ctrl`+`shift`+`i` combination. If you're not a developer, best to leave this off.
 
 ### Debugger Hotkey
 
@@ -125,8 +120,8 @@ This option allows you to add RDT to Discord. Currently, it is required that you
 
 ### Inspect Element Hotkey
 
-This option adds a new keybind `ctrl`+`shift`+`c` that opens DevTools and starts selecting element. If DevTools are open it immediately activates the select element action.
+This option adds a new keybind `ctrl`+`shift`+`c` that opens DevTools and starts selecting elements. If DevTools are open it immediately activates the select element action.
 
 ### Stop DevTools Warning
 
-This option stops Discord from printing out those large warnings you see in console.
+This option stops Discord from printing out those large warnings you see in the console.

--- a/docs/users/getting-started/installation.mdx
+++ b/docs/users/getting-started/installation.mdx
@@ -77,7 +77,7 @@ pnpm install
 
 #### 4. Build BetterDiscord
 
-This will create `injector.js`, `preload.js`, and `renderer.js` in the `dist/` folder.
+This will create an `injector.js`, `preload.js`, and `renderer.js` in the `dist/` folder.
 ```bash
 pnpm build
 ```

--- a/docs/users/getting-started/installation.mdx
+++ b/docs/users/getting-started/installation.mdx
@@ -77,7 +77,7 @@ pnpm install
 
 #### 4. Build BetterDiscord
 
-This will create a `injector.js`, `preload.js`, and `renderer.js` in the `dist/` folder.
+This will create `injector.js`, `preload.js`, and `renderer.js` in the `dist/` folder.
 ```bash
 pnpm build
 ```

--- a/docs/users/getting-started/troubleshooting.md
+++ b/docs/users/getting-started/troubleshooting.md
@@ -52,11 +52,11 @@ This is usually an issue with Discord moving around its installation location on
 <details>
 <summary>Installer won't open</summary>
 
-If you are on Linux try rnning with the `--no-sandbox`
+If you are on Linux try running with the `--no-sandbox`
 
 If the installer does not seem to open, follow these steps:
 1. Download and install [7-Zip](https://www.7-zip.org/)
-1. Right click and extract the BetterDiscord installer into a folder.
+1. Right-click and extract the BetterDiscord installer into a folder.
 1. Run the exe found in the folder.
 
 OR
@@ -68,7 +68,7 @@ Follow the [manual installation](../getting-started/installation/#manual-install
 <summary>Installer is all black</summary>
 
 Try one of the following:
- - Right click the installer and select run as Administrator.
+ - Right-click the installer and select run as Administrator.
  - Open the command prompt by pressing `win`+`r` type `cmd` and press enter. Then type `ipconfig /flushdns` and press enter in the window that appears.
  - Disable your anti-virus temporarily.
 

--- a/docs/users/guides/installing-addons.md
+++ b/docs/users/guides/installing-addons.md
@@ -7,7 +7,7 @@ description: How to extend BetterDiscord.
 
 ## Video
 
-The second half of this video shows exaclty how to install addons.
+The second half of this video shows exactly how to install addons.
 
 <iframe width="850" height="478" src="https://www.youtube.com/embed/U0tTENsBS4w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/users/guides/vanilla.mdx
+++ b/docs/users/guides/vanilla.mdx
@@ -14,7 +14,7 @@ This feature requires some basic computer literacy.
 
 :::
 
-BetterDiscord allows you to return to vanilla Discord functionality without having to remove BetterDiscord. This is useful for those that like to switch back and forth. This is done using the `--vanilla` command line flag. There are two ways this can be used. You can either do this as a one-off, or setup a shortcut for yourself to easily boot between normal Discord and BetterDiscord.
+BetterDiscord allows you to return to vanilla Discord functionality without having to remove BetterDiscord. This is useful for those that like to switch back and forth. This is done using the `--vanilla` command line flag. There are two ways this can be used. You can either do this as a one-off or setup a shortcut for yourself to easily boot between normal Discord and BetterDiscord.
 
 
 ## One-off
@@ -25,7 +25,7 @@ Running vanilla Discord as a one-off means next time you launch Discord, BetterD
 <TabItem value="windows">
 
 1. Ensure Discord is fully closed
-1. Right click your existing Discord shortcut and select `Properties`
+1. Right-click your existing Discord shortcut and select `Properties`
 1. Copy the `Target` field
 1. Open command prompt by pressing `⊞ win`+`r`
 1. Paste the value of the `Target` field and add a space and `--vanilla` at the end
@@ -42,7 +42,7 @@ Running vanilla Discord as a one-off means next time you launch Discord, BetterD
 <TabItem value="linux">
 
 1. Ensure Discord is fully closed
-1. Open preferred terminal
+1. Open a preferred terminal
 1. Run `discord --vanilla`
 
 </TabItem>
@@ -56,8 +56,8 @@ Creating a separate shortcut makes it easy to launch with either vanilla Discord
 <TabItem value="windows">
 
 1. Ensure Discord is fully closed
-1. Right click your existing Discord shortcut and select `Create Shortcut`
-1. Right click the new shortcut `Discord (2)` and select `Properties`
+1. Right-click your existing Discord shortcut and select `Create Shortcut`
+1. Right-click the new shortcut `Discord (2)` and select `Properties`
 1. In the target field add a space followed by `--vanilla` at the end of the field
 1. Click `OK`
 1. Rename your new shortcut to something like `Discord Vanilla`
@@ -66,9 +66,9 @@ Creating a separate shortcut makes it easy to launch with either vanilla Discord
 <TabItem value="mac">
 
 1. Ensure Discord is fully closed
-1. Open Automator app (`⌘ Command`+`Spacebar`)
+1. Open the Automator app (`⌘ Command`+`Spacebar`)
 1. Select `New Document` then `Application`
-1. From the menu on the left drag `Run Shell Script` to the right hand side.
+1. From the menu on the left drag `Run Shell Script` to the right-hand side.
 1. On the right, in the textbox that appears, paste in `open -a '/Applications/Discord.app' --args --vanilla`
 1. At the top, name your application something like `Discord Vanilla` and set `Where` to be the `Applications` folder
 1. Go to `File > Save` to finalize

--- a/docs/users/guides/vanilla.mdx
+++ b/docs/users/guides/vanilla.mdx
@@ -42,7 +42,7 @@ Running vanilla Discord as a one-off means next time you launch Discord, BetterD
 <TabItem value="linux">
 
 1. Ensure Discord is fully closed
-1. Open a preferred terminal
+1. Open preferred terminal
 1. Run `discord --vanilla`
 
 </TabItem>

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -25,7 +25,7 @@ BetterDiscord fully integrates Twitch emotes sourced from BTTV, Twitch, and FFZ.
 
 ### Live Editor
 
-BetterDiscord allows you to modify your Discord application and see the changes apply in real time.
+BetterDiscord allows you to modify your Discord application and see the changes apply in real-time.
 
 ### Transparency
 
@@ -33,7 +33,7 @@ BetterDiscord can make the Discord application partially see-through leading to 
 
 ### Public Servers
 
-BetterDiscord adds a public server directory sourced from [DiscordServers.com](https://discordservers.com/). This is different from the built-in discovery feature of Discord because DiscordServer is a community run listing and does not have the same requirements as discovery.
+BetterDiscord adds a public server directory sourced from [DiscordServers.com](https://discordservers.com/). This is different from the built-in discovery feature of Discord because DiscordServer is a community-run listing and does not have the same requirements as discovery.
 
 ### Dual Boot
 
@@ -45,7 +45,7 @@ Plugins can increase the functionality and user experience of the app through Ja
 
 ### Themes
 
-Themes allow you to completely customize your client with CSS. You can either make your own theme, or download the wide variety of themes from our community.
+Themes allow you to completely customize your client with CSS. You can either make your own theme or download the wide variety of themes from our community.
 
 ## Keep in Touch
 - [Discord](https://betterdiscord.app/invite)

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -25,15 +25,11 @@ BetterDiscord fully integrates Twitch emotes sourced from BTTV, Twitch, and FFZ.
 
 ### Live Editor
 
-BetterDiscord allows you to modify your Discord application and see the changes apply in real-time.
+BetterDiscord allows you to modify your Discord application and see the changes apply in real time.
 
 ### Transparency
 
 BetterDiscord can make the Discord application partially see-through leading to very cool designs and desktop environments.
-
-### Public Servers
-
-BetterDiscord adds a public server directory sourced from [DiscordServers.com](https://discordservers.com/). This is different from the built-in discovery feature of Discord because DiscordServer is a community-run listing and does not have the same requirements as discovery.
 
 ### Dual Boot
 


### PR DESCRIPTION
This PR just fixes typos found in the User Guides section of the docs, and updates some outdated information (settings in bd that no longer exist) in ```users/getting-started/configuration.md```.