### PR TITLE
Remove Reference to Emote integration

### DIFF
--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -19,10 +19,6 @@ Understand the basics in **under 2 minutes** by following this video guide:
 
 ## Core Features
 
-### Twitch Emotes
-
-BetterDiscord fully integrates Twitch emotes sourced from BTTV, Twitch, and FFZ.
-
 ### Live Editor
 
 BetterDiscord allows you to modify your Discord application and see the changes apply in real time.


### PR DESCRIPTION
This removes the reference to Twitch, FFZ, and BTTV emote integration. This integration was removed with https://github.com/BetterDiscord/BetterDiscord/commit/d2a1a29d6d9773f7f98c620198e3b2544738d8ba, which was well over a year ago.