### PR TITLE
fix broken relative links

### DIFF
--- a/docs/api/addonapi.md
+++ b/docs/api/addonapi.md
@@ -1,6 +1,6 @@
 # AddonAPI
 
-`AddonAPI` is a utility class for working with plugins and themes. Instances are accessible through the [BdApi](./bdapi).
+`AddonAPI` is a utility class for working with plugins and themes. Instances are accessible through the [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/bdapi.md
+++ b/docs/api/bdapi.md
@@ -5,37 +5,37 @@
 ## Properties
 
 ### ContextMenu
-An instance of [ContextMenu](./contextmenu) for interacting with context menus.
+An instance of [ContextMenu](./contextmenu.md) for interacting with context menus.
 
 **Type:** `ContextMenu`
 ___
 
 ### DOM
-An instance of [DOM](./dom) to interact with the DOM.
+An instance of [DOM](./dom.md) to interact with the DOM.
 
 **Type:** `DOM`
 ___
 
 ### Data
-An instance of [Data](./data) to manage data.
+An instance of [Data](./data.md) to manage data.
 
 **Type:** `Data`
 ___
 
 ### Net
-An instance of [Net](./net) for networking requests.
+An instance of [Net](./net.md) for networking requests.
 
 **Type:** `Net`
 ___
 
 ### Patcher
-An instance of [Patcher](./patcher) to monkey patch functions.
+An instance of [Patcher](./patcher.md) to monkey patch functions.
 
 **Type:** `Patcher`
 ___
 
 ### Plugins
-An instance of [AddonAPI](./addonapi) to access plugins.
+An instance of [AddonAPI](./addonapi.md) to access plugins.
 
 **Type:** `AddonAPI`
 ___
@@ -53,31 +53,31 @@ The ReactDOM module being used inside Discord.
 ___
 
 ### ReactUtils
-An instance of [ReactUtils](./reactutils) to work with React.
+An instance of [ReactUtils](./reactutils.md) to work with React.
 
 **Type:** `ReactUtils`
 ___
 
 ### Themes
-An instance of [AddonAPI](./addonapi) to access themes.
+An instance of [AddonAPI](./addonapi.md) to access themes.
 
 **Type:** `AddonAPI`
 ___
 
 ### UI
-An instance of [UI](./ui) to create interfaces.
+An instance of [UI](./ui.md) to create interfaces.
 
 **Type:** `UI`
 ___
 
 ### Utils
-An instance of [Utils](./utils) for general utility functions.
+An instance of [Utils](./utils.md) for general utility functions.
 
 **Type:** `Utils`
 ___
 
 ### Webpack
-An instance of [Webpack](./webpack) to search for modules.
+An instance of [Webpack](./webpack.md) to search for modules.
 
 **Type:** `Webpack`
 ___

--- a/docs/api/contextmenu.md
+++ b/docs/api/contextmenu.md
@@ -1,6 +1,6 @@
 # ContextMenu
 
-`ContextMenu` is a module to help patch and create context menus. Instance is accessible through the [BdApi](./bdapi).
+`ContextMenu` is a module to help patch and create context menus. Instance is accessible through the [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -1,6 +1,6 @@
 # Data
 
-`Data` is a simple utility class for the management of plugin data. An instance is available on [BdApi](./bdapi).
+`Data` is a simple utility class for the management of plugin data. An instance is available on [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/dom.md
+++ b/docs/api/dom.md
@@ -1,6 +1,6 @@
 # DOM
 
-`DOM` is a simple utility class for dom manipulation. An instance is available on [BdApi](./bdapi).
+`DOM` is a simple utility class for dom manipulation. An instance is available on [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/filters.md
+++ b/docs/api/filters.md
@@ -1,6 +1,6 @@
 # Filters
 
-Series of [Filters](./filters) to be used for finding webpack modules.
+Series of [Filters](./filters.md) to be used for finding webpack modules.
 
 ## Properties
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -6,7 +6,7 @@ This module is still in beta and is subject to change. This API is mostly finali
 
 :::
 
-`Net` is a namespace for networking related utility functions. Instance is accessible through the [BdApi](./bdapi).
+`Net` is a namespace for networking related utility functions. Instance is accessible through the [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/patcher.md
+++ b/docs/api/patcher.md
@@ -1,6 +1,6 @@
 # Patcher
 
-`Patcher` is a utility class for modifying existing functions. Instance is accessible through the [BdApi](./bdapi). This is extremely useful for modifying the internals of Discord by adjusting return value or React renders, or arguments of internal functions.
+`Patcher` is a utility class for modifying existing functions. Instance is accessible through the [BdApi](./bdapi.md). This is extremely useful for modifying the internals of Discord by adjusting return value or React renders, or arguments of internal functions.
 
 ## Properties
 

--- a/docs/api/reactutils.md
+++ b/docs/api/reactutils.md
@@ -1,6 +1,6 @@
 # ReactUtils
 
-`ReactUtils` is a utility class for interacting with React internals. Instance is accessible through the [BdApi](./bdapi). This is extremely useful for interacting with the internals of the UI.
+`ReactUtils` is a utility class for interacting with React internals. Instance is accessible through the [BdApi](./bdapi.md). This is extremely useful for interacting with the internals of the UI.
 
 ## Properties
 

--- a/docs/api/ui.md
+++ b/docs/api/ui.md
@@ -1,6 +1,6 @@
 # UI
 
-`UI` is a utility class for creating user interfaces. Instance is accessible through the [BdApi](./bdapi).
+`UI` is a utility class for creating user interfaces. Instance is accessible through the [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,6 +1,6 @@
 # Utils
 
-`Utils` is a utility containing commonly reused functions. Instance is accessible through the [BdApi](./bdapi).
+`Utils` is a utility containing commonly reused functions. Instance is accessible through the [BdApi](./bdapi.md).
 
 ## Properties
 

--- a/docs/api/webpack.md
+++ b/docs/api/webpack.md
@@ -1,11 +1,11 @@
 # Webpack
 
-`Webpack` is a utility class for getting internal webpack modules. Instance is accessible through the [BdApi](./bdapi). This is extremely useful for interacting with the internals of Discord.
+`Webpack` is a utility class for getting internal webpack modules. Instance is accessible through the [BdApi](./bdapi.md). This is extremely useful for interacting with the internals of Discord.
 
 ## Properties
 
 ### Filters
-Series of [Filters](./filters) to be used for finding webpack modules.
+Series of [Filters](./filters.md) to be used for finding webpack modules.
 
 **Type:** `Filters`
 ___

--- a/docs/plugins/basics/creating-a-plugin.mdx
+++ b/docs/plugins/basics/creating-a-plugin.mdx
@@ -13,7 +13,7 @@ Knowing what you want the plugin to do also allows you to reach out to our commu
 
 ## The Style
 
-Next, you'll need to decide which plugin style to use. As seen in the [plugin structure](../introduction/structure) docs, there a couple different ways to go about it. They are shown again below for clarity. Each one has pros and cons, but can each work well for simple to advanced plugins. In the end it ultimately comes down to the individual developer's style preference. A mix of the styles will be shown here in the docs.
+Next, you'll need to decide which plugin style to use. As seen in the [plugin structure](../introduction/structure.md) docs, there a couple different ways to go about it. They are shown again below for clarity. Each one has pros and cons, but can each work well for simple to advanced plugins. In the end it ultimately comes down to the individual developer's style preference. A mix of the styles will be shown here in the docs.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -100,7 +100,7 @@ module.exports = meta => {
 
 It's worth noting when deciding that each plugin is loaded similarly to a node module. This means that defining variables outside of the `module.exports` will not result in scope creep or variable bloat.
 
-Once you've got that decided, go ahead and save your template in your [plugins folder](../introduction/quick-start#plugin-folder) as `ExamplePlugin.plugin.js` and change `ExamplePlugin` to the name of your choice.
+Once you've got that decided, go ahead and save your template in your [plugins folder](../introduction/quick-start.mdx/#plugin-folder) as `ExamplePlugin.plugin.js` and change `ExamplePlugin` to the name of your choice.
 
 
 ## Things to Keep in Mind
@@ -109,8 +109,8 @@ There's a lot to keep in mind as you develop your plugin. One of the most import
 
 If you're looking to submit this plugin, or share it with others, it's worth keeping in mind what parts of the plugin are opinionated. For example, the way something is formatted or styled may look good to some and not to others.
 
-If you have these things in mind while you develop, you can add unique classes to elements for themes and users to take advantage of, or even add [plugin settings](./settings) which we'll get to a bit later.
+If you have these things in mind while you develop, you can add unique classes to elements for themes and users to take advantage of, or even add [plugin settings](./settings.mdx) which we'll get to a bit later.
 
 ## What's Next?
 
-If you feel comfortable with everything so far, you're probably safe to move on to making your plugin by first [interacting with the dom](./dom). Otherwise, take the time and experiment with the plugin templates and see what feels right, maybe even brush up on your JavaScript skills.
+If you feel comfortable with everything so far, you're probably safe to move on to making your plugin by first [interacting with the dom](./dom.md). Otherwise, take the time and experiment with the plugin templates and see what feels right, maybe even brush up on your JavaScript skills.

--- a/docs/plugins/basics/dom.md
+++ b/docs/plugins/basics/dom.md
@@ -7,7 +7,7 @@ description: How to use DOM manipulation.
 
 If you're unfamiliar with the DOM it might be worth taking a look at the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) about it.
 
-Since we already know from [previous pages](../introduction/environment) that Discord is essentially a Chromium browser, we can access the DOM using typical methods.
+Since we already know from [previous pages](../introduction/environment.md) that Discord is essentially a Chromium browser, we can access the DOM using typical methods.
 
 ```js
 // Create a reference to the document
@@ -41,7 +41,7 @@ One thing to note from this code is the root container `document.getElementById(
 
 And while that works, it's not very practical or useful. And the location of the button is terrible. So what if we wanted to add it to the end of the guild/server list? Let's give it a try!
 
-First, we need to find the DOM subtree for the guild list, the easiest way to do that is to use inspect element from [devtools](../../developers/devtools) and select the guild list on the left.
+First, we need to find the DOM subtree for the guild list, the easiest way to do that is to use inspect element from [devtools](/developers/devtools) and select the guild list on the left.
 
 ![Server List](./img/servers.png)
 

--- a/docs/plugins/basics/settings.mdx
+++ b/docs/plugins/basics/settings.mdx
@@ -9,7 +9,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 # Plugin Settings
 
-In BetterDiscord, plugins settings are very open-ended and flexible; there is no one correct way to do them. In this section we're going to look at one way to manage your settings. This includes using BetterDiscord to save and load the settings data, and making use of the `getSettingsPanel` function described in [plugin structure](../introduction/structure).
+In BetterDiscord, plugins settings are very open-ended and flexible; there is no one correct way to do them. In this section we're going to look at one way to manage your settings. This includes using BetterDiscord to save and load the settings data, and making use of the `getSettingsPanel` function described in [plugin structure](../introduction/structure.md).
 
 Using `getSettingsPanel` is the recommended way to show a settings panel to the user because it creates a consistent flow for the user. If every plugin added a button in the Discord UI for their own settings button, it could end up chaotic. Instead using `getSettingsPanel` allows your plugin to have a settings button on the plugins page in the BetterDiscord settings. Most users will expect a plugin to implement this if they have settings of any kind.
 
@@ -473,7 +473,7 @@ mySettingsPanel.append(buttonText, darkMode);
 
 As we can see here, this will now allow the saved value of the settings to be shown when the panel opens, and it will also allow the user to update the settings. And thanks to our helper function, these values will also be saved.
 
-If we put all the pieces together and combine it with the button we made in the [DOM](./dom) section, we might end up with a plugin like this:
+If we put all the pieces together and combine it with the button we made in the [DOM](./dom.md) section, we might end up with a plugin like this:
 
 ```js
 /**
@@ -552,4 +552,4 @@ If we put all the pieces together and combine it with the button we made in the 
 
 The new pieces here are the update functions `updateButtonText` and `updateButtonTheme` which are pretty straight-forward if you read through them. Otherwise, feel free to save this into your plugins folder and give it a test run. If you completed this section, you've successfully learned how to make a plugin with settings that actually work!
 
-When you're ready to move on, check out the next chapter, [UI Components](./ui), that goes over different UI elements within Discord and BetterDiscord.
+When you're ready to move on, check out the next chapter, [UI Components](./ui.mdx), that goes over different UI elements within Discord and BetterDiscord.

--- a/docs/plugins/introduction/environment.md
+++ b/docs/plugins/introduction/environment.md
@@ -37,4 +37,4 @@ BetterDiscord provides an API for plugins. The guides here show how it's used an
 
 ## Discord's Internals
 
-Inside of this environment, BetterDiscord provides access to Discord's internals via searching their modules. Understanding and using these modules is a task left to the developer. But the [advanced](../advanced/) guide provides some insight on how to get started. Searching through and using Discord's own modules are some of the most important skills for building complex plugins.
+Inside of this environment, BetterDiscord provides access to Discord's internals via searching their modules. Understanding and using these modules is a task left to the developer. But the [advanced](../../advanced) guide provides some insight on how to get started. Searching through and using Discord's own modules are some of the most important skills for building complex plugins.

--- a/docs/plugins/introduction/structure.md
+++ b/docs/plugins/introduction/structure.md
@@ -87,7 +87,7 @@ All of those examples are valid ways of getting those functions back to BetterDi
 
 It may seem roundabout to do it this way, but this is what allows for developers to make use of uninstantiated classes like the example above.
 
-If you feel you have a solid grasp of how this works, take a look at the [Guidelines](./guidelines) before moving on to the [Basics](../basics) guide.
+If you feel you have a solid grasp of how this works, take a look at the [Guidelines](./guidelines.md) before moving on to the [Basics](../../basics) guide.
 
 #### Optional Functions
 

--- a/docs/themes/introduction/structure.md
+++ b/docs/themes/introduction/structure.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 :::info
 
-This page only goes over the body of a theme. Make sure you have read up on the [addon system](../../developers/addons.md) first.
+This page only goes over the body of a theme. Make sure you have read up on the [addon system](/developers/addons.md) first.
 
 :::
 
@@ -20,4 +20,4 @@ Theme files are split into two main pieces, the meta and the css. If either of t
 
 ### CSS
 
-Unlike [plugins](../../plugins), themes are left open-ended and unstructured. This allows for full developer control of the theme.
+Unlike [plugins](/plugins), themes are left open-ended and unstructured. This allows for full developer control of the theme.

--- a/docs/users/getting-started/installation.mdx
+++ b/docs/users/getting-started/installation.mdx
@@ -7,7 +7,7 @@ description: Quick guide to getting BetterDiscord.
 
 :::caution
 
-If you experience any issues following these steps, try the [troubleshooting](./troubleshooting) guide.
+If you experience any issues following these steps, try the [troubleshooting](./troubleshooting.md) guide.
 
 :::
 

--- a/docs/users/getting-started/troubleshooting.md
+++ b/docs/users/getting-started/troubleshooting.md
@@ -61,7 +61,7 @@ If the installer does not seem to open, follow these steps:
 
 OR
 
-Follow the [manual installation](../getting-started/installation/#manual-installation) instruction.
+Follow the [manual installation](./installation.mdx/#manual-installation) instruction.
 </details>
 
 <details>
@@ -74,7 +74,7 @@ Try one of the following:
 
 OR
 
-Follow the [manual installation](../getting-started/installation/#manual-installation) instruction.
+Follow the [manual installation](./installation.mdx/#manual-installation) instruction.
 </details>
 
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,6 +11,7 @@ const config = {
   url: "https://docs.zerebos.com",
   baseUrl: "/",
   onBrokenLinks: "throw",
+  trailingSlash: true,
   onBrokenMarkdownLinks: "warn",
   favicon: "favicon/favicon-96x96.png",
   organizationName: "betterdiscord",


### PR DESCRIPTION
Currently relative links are a bit scuffed under a few conditions, hopefully this fixes them. 

Example below: 

https://github.com/user-attachments/assets/236ef163-0217-4cbd-8f32-a0eabdc7bb9c

There are a few other examples throughout the docs. 

Not sure if this is the correct way to do this, didn't really look at how the docs were built, seemed to build and test fine locally, though