### PR TITLE
Add CLI guide and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+notes/

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -167,6 +167,10 @@ const VITEPRESS_CONFIG: UserConfig<DefaultTheme.Config> = {
                     "json": "vscode-icons:file-type-json",
                     ".plugin.js": bdIcon,
                     ".theme.css": bdIcon,
+                    "homebrew": "https://brew.sh/assets/img/homebrew.svg",
+                    "go": "https://go.dev/images/favicon-gopher.svg",
+                    ".go": "https://go.dev/images/favicon-gopher.svg",
+                    "winget": "vscode-icons:file-type-favicon",
                     // TODO: consider adding platform icons
                 },
             })

--- a/docs/users/getting-started/installation.md
+++ b/docs/users/getting-started/installation.md
@@ -40,7 +40,73 @@ If you prefer a video tutorial, take a look at this:
 
 
 
+## Command Line Installation
+
+If you're comfortable using a terminal, the BetterDiscord CLI lets you install and update quickly. For full details, see the [CLI guide](../guides/cli).
+
+### Install the CLI
+
+Choose one of these methods:
+
+::: code-group
+```bash [npm]
+npm install -g @betterdiscord/cli
+```
+
+```bash [Homebrew]
+brew install betterdiscord/tap/bdcli
+```
+
+
+```bash [winget]
+winget install betterdiscord.cli
+```
+
+```bash [Go]
+go install github.com/betterdiscord/cli@latest
+```
+
+```bash [Binary]
+# Download the latest release for your platform
+# https://github.com/BetterDiscord/cli/releases
+```
+:::
+
+### Install BetterDiscord
+
+Most people can use the Stable channel:
+
+```bash
+bdcli install --channel stable
+```
+
+Other channels are available too:
+
+```bash
+bdcli install --channel ptb
+bdcli install --channel canary
+```
+
+If Discord is installed in a custom location, point to it directly:
+
+```bash
+bdcli install --path /path/to/Discord
+```
+
+
+Notes:
+- If neither `--path` nor `--channel` is specified, it defaults to Stable.
+- The `--path` and `--channel` flags are mutually exclusive.
+
+
+
 ## Manual Installation
+
+::: danger
+
+This section is primarily meant for developers and contributors to BetterDiscord. Users should only do this as a last resort.
+
+:::
 
 For those that can't get the automatic installers to work, those that want more control over their installation, and for developers.
 

--- a/docs/users/guides/cli.md
+++ b/docs/users/guides/cli.md
@@ -1,0 +1,237 @@
+---
+order: 3
+description: Control BetterDiscord from the command line.
+---
+
+
+# BetterDiscord CLI
+
+A cross-platform command-line interface for installing, updating, and managing [BetterDiscord](https://betterdiscord.app/).
+
+## Features
+
+- 🚀 Easy installation and uninstallation of BetterDiscord
+- 🔄 Support for multiple Discord channels (Stable, PTB, Canary)
+- 🖥️ Cross-platform support (Windows, macOS, Linux)
+- 📦 Available via npm for easy distribution
+- ⚡ Fast and lightweight Go binary
+
+## Installation
+
+### Via npm
+
+```bash
+npm install -g @betterdiscord/cli
+```
+
+### Via Homebrew/Linuxbrew
+
+```bash
+brew install betterdiscord/tap/bdcli
+```
+
+### Via winget (Windows)
+
+```bash
+winget install betterdiscord.cli
+```
+
+### Via Go
+
+```bash
+go install github.com/betterdiscord/cli@latest
+```
+
+### Download Binary
+
+Download the latest release for your platform from the [releases page](https://github.com/BetterDiscord/cli/releases).
+
+## Commands
+
+### Install
+
+Install BetterDiscord to your Discord installation.
+
+#### By Channel
+
+Auto-detect Discord installation based on the release channel:
+
+```bash
+bdcli install --channel stable   # Install to Discord Stable (default)
+bdcli install --channel ptb      # Install to Discord PTB
+bdcli install --channel canary   # Install to Discord Canary
+```
+
+#### By Custom Path
+
+Specify a custom path to any Discord installation:
+
+```bash
+bdcli install --path /path/to/Discord
+# Or using short flag:
+bdcli install -p /path/to/Discord
+```
+
+#### Notes
+
+- If neither `--path` nor `--channel` is specified, it defaults to the Stable channel
+- The `--path` and `--channel` flags are mutually exclusive
+
+### Uninstall
+
+Remove BetterDiscord from your Discord installation.
+
+#### By Channel
+
+```bash
+bdcli uninstall --channel stable   # Uninstall from Discord Stable (default)
+bdcli uninstall --channel ptb      # Uninstall from Discord PTB
+bdcli uninstall --channel canary   # Uninstall from Discord Canary
+```
+
+#### By Custom Path
+
+Specify a custom path to any Discord installation:
+
+```bash
+bdcli uninstall --path /path/to/Discord
+# Or using short flag:
+bdcli uninstall -p /path/to/Discord
+```
+
+#### Notes
+
+- If neither `--path` nor `--channel` is specified, it defaults to the Stable channel
+- The `--path` and `--channel` flags are mutually exclusive
+
+### Version
+
+Display version information about the CLI:
+
+```bash
+bdcli version
+```
+
+Output example:
+```
+BetterDiscord CLI v1.0.0
+Commit: abc123def456
+Built:  2025-02-15T10:30:00Z
+```
+
+### Completion
+
+Generate shell completion scripts for bash, zsh, or fish:
+
+```bash
+bdcli completion bash  # Generate bash completion
+bdcli completion zsh   # Generate zsh completion
+bdcli completion fish  # Generate fish completion
+```
+
+To enable completions, source the output in your shell configuration file.
+
+## Help
+
+Get help information about the CLI or any command:
+
+```bash
+bdcli --help              # Show general help
+bdcli [command] --help    # Show help for a specific command
+```
+
+### Available Commands
+
+```
+A cross-platform CLI for installing, updating, and managing BetterDiscord.
+
+Usage:
+   bdcli [flags]
+   bdcli [command]
+
+Available Commands:
+   completion  Generate shell completions
+   help        Help about any command
+   install     Installs BetterDiscord to your Discord
+   uninstall   Uninstalls BetterDiscord from your Discord
+   version     Print the version number
+
+Flags:
+   -h, --help   help for bdcli
+
+Use "bdcli [command] --help" for more information about a command.
+```
+
+## Supported Platforms
+
+The CLI is available for multiple platforms and architectures:
+
+- **Windows** (x64, ARM64, x86)
+- **macOS** (x64, ARM64/M1/M2)
+- **Linux** (x64, ARM64, ARM)
+
+## Common Use Cases
+
+### First Time Installation
+
+1. **Install from stable channel (recommended):**
+   ```bash
+   bdcli install
+   ```
+
+2. **Or install to a specific channel:**
+   ```bash
+   bdcli install --channel ptb
+   ```
+
+### Using Multiple Discord Installations
+
+You can manage multiple Discord installations by specifying custom paths:
+
+```bash
+# Install to your custom Discord location
+bdcli install --path /opt/discord-custom
+
+# Later, uninstall from the same location
+bdcli uninstall --path /opt/discord-custom
+```
+
+### Verify Installation
+
+After installing, you can verify the version of the CLI:
+
+```bash
+bdcli version
+```
+
+## Troubleshooting
+
+### Discord Installation Not Found
+
+If you get an error like "could not find a valid Discord installation":
+
+1. **Check if Discord is installed** at the default location for your platform
+2. **Use custom path** if Discord is installed elsewhere:
+   ```bash
+   bdcli install --path /your/custom/discord/path
+   ```
+
+### Mutually Exclusive Flags
+
+You cannot use both `--path` and `--channel` in the same command. Choose one:
+
+```bash
+# ✅ Correct
+bdcli install --channel stable
+
+# ✅ Correct
+bdcli install --path /custom/path
+
+# ❌ Not allowed
+bdcli install --channel stable --path /custom/path
+```
+
+## Additional Resources
+
+- [GitHub Repository](https://github.com/BetterDiscord/cli)
+- [Releases Page](https://github.com/BetterDiscord/cli/releases)


### PR DESCRIPTION
On the installation page there are CLI instructions as well as a new warning for the manual install:

<img width="716" height="1171" alt="image" src="https://github.com/user-attachments/assets/49aa9442-4782-412f-9473-57cf58eace75" />

and a new general CLI guide:

<img width="1480" height="1293" alt="image" src="https://github.com/user-attachments/assets/00441b38-5749-4a1e-a32d-5d2dae74e193" />
