### PR TITLE
Fix build failing

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,8 +1,8 @@
 # Overview
 
-The BetterDiscord API is available to plugins via the global [BdApi](BdApi.md) variable. It contains numerous utilities for things like creating user interfaces and working with Discord's internals. It is split up into several namespaces which are listed in the sidebar. If you are just starting out, it is recommended to read the [Plugin Developer Guide](/plugins) before diving into these docs.
+The BetterDiscord API is available to plugins via the global [BdApi](BdApi.md) variable. It contains numerous utilities for things like creating user interfaces and working with Discord's internals. It is split up into several namespaces which are listed in the sidebar. If you are just starting out, it is recommended to read the [Plugin Developer Guide](/plugins/index.md) before diving into these docs.
 
-Some methods (for example [Data.save](Data.md#save)) expect to be passed the name of the plugin calling them to avoid conflicts or so they can be cleaned up later. This can be done automatically by creating a bound instance of BdApi, which is done through instantiating it and passing it the name of your plugin, like so:
+Some methods (for example [Data.save](/api/Data.md#save)) expect to be passed the name of the plugin calling them to avoid conflicts or so they can be cleaned up later. This can be done automatically by creating a bound instance of BdApi, which is done through instantiating it and passing it the name of your plugin, like so:
 
 ```js
 const Api = new BdApi("MyPlugin");

--- a/docs/discord/modules/data-stores.md
+++ b/docs/discord/modules/data-stores.md
@@ -1,6 +1,6 @@
 # Data Stores
 
-This is a reference of most of available internal data stores as well as their properties and methods. All the store listed here can be found through [`BdApi.Webpack.getStore()`](/api/classes/Webpack.md#getstore) using the names seen here.
+This is a reference of most of available internal data stores as well as their properties and methods. All the store listed here can be found through [`BdApi.Webpack.getStore()`](/api/Webpack.md#getstore) using the names seen here.
 
 
 ## Useful Snippets

--- a/docs/discord/modules/index.md
+++ b/docs/discord/modules/index.md
@@ -8,7 +8,7 @@ description: Internal module reference.
 > [!IMPORTANT]
 > Keep in mind that Discord's internals are not officially documented and are subject to change at any time. You can check the timestamp at the bottom of each page to see when the reference was last updated.
 
-Discord uses Webpack as their bundler and through [`BdApi.Webpack`](/api/classes/Webpack.md) we are able to grab a number of their internal modules for our own use. There are several commonly known types of modules and this section of the documentation serves as a living reference of some of these modules.
+Discord uses Webpack as their bundler and through [`BdApi.Webpack`](/api/Webpack.md) we are able to grab a number of their internal modules for our own use. There are several commonly known types of modules and this section of the documentation serves as a living reference of some of these modules.
 
 ## Data Stores
 

--- a/docs/plugins/concepts/webpack.md
+++ b/docs/plugins/concepts/webpack.md
@@ -24,7 +24,7 @@ Plugins are able to access all of these types of modules through BetterDiscord's
 
 ## Finding Modules
 
-How do we actually find these modules? First, let's take a look at the tools at our disposal. We of course have the Chromium DevTools as we talked about in our [developer guide](../introduction/devtools.md), which is absolutely crucial. But we also have BetterDiscord's Webpack API. You can take a look at the [API reference](/api/classes/Webpack.md) for this namespace if you want a full list, we'll be going over the most frequently used ones here.
+How do we actually find these modules? First, let's take a look at the tools at our disposal. We of course have the Chromium DevTools as we talked about in our [developer guide](../introduction/devtools.md), which is absolutely crucial. But we also have BetterDiscord's Webpack API. You can take a look at the [API reference](/api/Webpack.md) for this namespace if you want a full list, we'll be going over the most frequently used ones here.
 
 ## Filters
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -16,7 +16,7 @@ These docs consist of this introduction which gives you an idea of what to expec
 
 The [Introduction](./introduction/quick-start.md) section gives a lot of background information on plugins requirements, the development environment, and the tools at your disposal.
 
-The [Tutorials](./tutorials/creating-a-plugin.md) section walks you through the basics of making plugins including code snippets and explanation. It also goes over most of what [BdApi](/api/classes/BdApi.md) has to offer.
+The [Tutorials](./tutorials/creating-a-plugin.md) section walks you through the basics of making plugins including code snippets and explanation. It also goes over most of what [BdApi](/api/BdApi.md) has to offer.
 
 The [Concepts](./concepts/patching.md) guide goes more in depth with advanced concepts that are important to making good and complicated plugins that smoothly integrate into Discord.
 

--- a/docs/plugins/tutorials/dom.md
+++ b/docs/plugins/tutorials/dom.md
@@ -105,7 +105,7 @@ const observerOptions = {
 myObserver.observe(serverList, observerOptions);
 ```
 
-This will now re-append the button anytime it is removed from the server list. The code is a little inconvenient to write, and it's very specific to that button. But thankfully, [BdApi](/api/classes/BdApi.md) has a utility function that can help called `onRemoved`. This code rewritten would look something like this:
+This will now re-append the button anytime it is removed from the server list. The code is a little inconvenient to write, and it's very specific to that button. But thankfully, [BdApi](/api/BdApi.md) has a utility function that can help called `onRemoved`. This code rewritten would look something like this:
 
 ```js
 // This part adds our button

--- a/docs/plugins/tutorials/react.md
+++ b/docs/plugins/tutorials/react.md
@@ -65,7 +65,7 @@ If you think that repeating `BdApi.React` over and over is a bit tedious, many d
 
 ## React in BetterDiscord
 
-Some of the [UI related functions](/api/classes/UI.md) of BetterDiscord accept React Components as options to be rendered. Some accept React Nodes/Elements which is just having already called `createElement`. One good example is the confirmation modal. It's already a very helpful utility, but adding in your own custom React component allows for some very powerful UI and UX for end users. Just as a quick example, take a look at how we can combine our `MyComponent` from before with the confirmation modal.
+Some of the [UI related functions](/api/UI.md) of BetterDiscord accept React Components as options to be rendered. Some accept React Nodes/Elements which is just having already called `createElement`. One good example is the confirmation modal. It's already a very helpful utility, but adding in your own custom React component allows for some very powerful UI and UX for end users. Just as a quick example, take a look at how we can combine our `MyComponent` from before with the confirmation modal.
 
 ```js
 BdApi.UI.showConfirmationModal("My Component Demo", BdApi.React.createElement(MyComponent));

--- a/docs/plugins/ui/changelogs.md
+++ b/docs/plugins/ui/changelogs.md
@@ -35,6 +35,6 @@ BdApi.UI.showChangelogModal({
 });
 ```
 
-You can check the [API reference](/api/classes/UI.md#showchangelogmodal) for more details, but this little snippet shows the most important features. Notably, this changelog API can also allow you to display a banner image, a YouTube video, or a direct video above all the text. This can be useful when you need to add a showcase of new things or if you just want to have a consistent branding. There are also 4 change "types". In the snippet we see fixed and added, there are also improved and progress.
+You can check the [API reference](/api/UI.md#showchangelogmodal) for more details, but this little snippet shows the most important features. Notably, this changelog API can also allow you to display a banner image, a YouTube video, or a direct video above all the text. This can be useful when you need to add a showcase of new things or if you just want to have a consistent branding. There are also 4 change "types". In the snippet we see fixed and added, there are also improved and progress.
 
 For now, plugins will have to decide when to display the changelog modal, though it is planned to be more automated in a future BetterDiscord update. For an example of how to do this check out this [Demo Plugin](https://gist.github.com/zerebos/b13adc05f22df008ee5d0411d9d18ff0) featuring the new APIs for BetterDiscord v1.11.0.

--- a/docs/plugins/ui/settings/overview.md
+++ b/docs/plugins/ui/settings/overview.md
@@ -22,7 +22,7 @@ You can then click through and test out the various settings and get a feel for 
 
 ## Concepts
 
-As mentioned above, BetterDiscord provides two high level ways of making use of these components. Using the React Components directly gives you more control and customization, but it also means it has fewer conveniences and helpers built-in. The documentation here will focus on the JSON-like API since that's our own custom API while React Components are pretty standard. You'll find a lot more information on the component details in the [API reference](../../../api/classes/Components.md).
+As mentioned above, BetterDiscord provides two high level ways of making use of these components. Using the React Components directly gives you more control and customization, but it also means it has fewer conveniences and helpers built-in. The documentation here will focus on the JSON-like API since that's our own custom API while React Components are pretty standard. You'll find a lot more information on the component details in the [API reference](/api/Components.md).
 
 For our JSON-like API we have 4 main components to consider, and it's important to know how they tie into one another. Let's start from the smallest consumable component and zoom out from there.
 
@@ -69,7 +69,7 @@ interface SettingItem {
 
 As you'll notice, most of these are optional, and they should all be understandable from name alone. The only one that might be a bit confusing is `id`. BetterDiscord uses this `id` to help keep all of your settings separate and give you an identifier to use when settings change. This isn't as important when doing single Setting Items, but when you create an entire panel at once, it's nice to know where the change is coming from. You'll see more on that in the next section.
 
-Each `SettingType` will require some other properties as well as providing other options. Visit those pages in the documentation for additional details or take a look at the [API reference](../../../api/classes/UI.md#buildsettingitem).
+Each `SettingType` will require some other properties as well as providing other options. Visit those pages in the documentation for additional details or take a look at the [API reference](/api/UI.md#buildsettingitem).
 
 ### `buildSettingsPanel()`
 


### PR DESCRIPTION
When converting to typedoc some links were not properly updated, which causes vitepress to fail.