### PR TITLE
Fix name of ReactDOM type in BdApi

### DIFF
--- a/docs/api/BdApi.md
+++ b/docs/api/BdApi.md
@@ -324,13 +324,13 @@ The React module being used inside Discord
 
 #### Get Signature
 
-> **get** **ReactDOM**(): `__module` & `__module`
+> **get** **ReactDOM**(): *typeof* `ReactDOMBase` & *typeof* `ReactDOMClient`
 
 The ReactDOM module being used inside Discord
 
 ##### Returns
 
-`__module` & `__module`
+*typeof* `ReactDOMBase` & *typeof* `ReactDOMClient`
 
 ***
 

--- a/scripts/data/apioverview.md
+++ b/scripts/data/apioverview.md
@@ -1,8 +1,8 @@
 # Overview
 
-The BetterDiscord API is available to plugins via the global [BdApi](BdApi.md) variable. It contains numerous utilities for things like creating user interfaces and working with Discord's internals. It is split up into several namespaces which are listed in the sidebar. If you are just starting out, it is recommended to read the [Plugin Developer Guide](/plugins) before diving into these docs.
+The BetterDiscord API is available to plugins via the global [BdApi](BdApi.md) variable. It contains numerous utilities for things like creating user interfaces and working with Discord's internals. It is split up into several namespaces which are listed in the sidebar. If you are just starting out, it is recommended to read the [Plugin Developer Guide](/plugins/index.md) before diving into these docs.
 
-Some methods (for example [Data.save](Data.md#save)) expect to be passed the name of the plugin calling them to avoid conflicts or so they can be cleaned up later. This can be done automatically by creating a bound instance of BdApi, which is done through instantiating it and passing it the name of your plugin, like so:
+Some methods (for example [Data.save](/api/Data.md#save)) expect to be passed the name of the plugin calling them to avoid conflicts or so they can be cleaned up later. This can be done automatically by creating a bound instance of BdApi, which is done through instantiating it and passing it the name of your plugin, like so:
 
 ```js
 const Api = new BdApi("MyPlugin");

--- a/scripts/docs-plugin.ts
+++ b/scripts/docs-plugin.ts
@@ -5,8 +5,8 @@ import { execSync } from "node:child_process";
 import { join } from "node:path";
 
 const propertyRegex = /(\n> (?:`static` )?\*\*\w+\*\*: .+) = `.+`\n/g;
-const replace = [
-    ["**ReactDOM**: `__module` & `__module`", "**ReactDOM**: *typeof* `ReactDOMBase` & *typeof* `ReactDOMClient`"]
+const replace: [string, string][] = [
+    ["`__module` & `__module`", "*typeof* `ReactDOMBase` & *typeof* `ReactDOMClient`"]
 ]
 
 export function load(app: MarkdownApplication) {


### PR DESCRIPTION
This fixes the ReactDOM type being listed as `__module & __module` in a few places. It also fixes the apioverview.md file not being in sync with index.md.